### PR TITLE
1 creating a job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    hashdiff (0.3.2)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     multi_xml (0.6.0)
+    public_suffix (2.0.5)
     rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -25,6 +31,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -34,6 +45,7 @@ DEPENDENCIES
   callback-ruby!
   rake
   rspec (~> 3.5.0)
+  webmock
 
 BUNDLED WITH
    1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,15 @@ PATH
   remote: .
   specs:
     callback-ruby (0.0.1)
+      httparty
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
+    httparty (0.14.0)
+      multi_xml (>= 0.5.2)
+    multi_xml (0.6.0)
     rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     callback-ruby (0.0.1)
+      hashie
       httparty
 
 GEM
@@ -13,6 +14,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     hashdiff (0.3.2)
+    hashie (3.4.6)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     multi_xml (0.6.0)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,35 @@ gem "callback"
 
 ## BASIC USAGE
 
+### Configure the Client
+
 You can configure Callback to use the API key for your team. If you are using Rails, you will want to create an initializer at `config/initializers/callback.rb`
 
 ```ruby
 Callback.configure do |config|
   config.access_token = ENV["CALLBACK_ACCESS_TOKEN"]
 end
+```
+
+### Creating a Client
+
+There are several endpoints that hang off of the client. The first thing you want to do is create a client.
+
+```
+client = Callback::Client.new(access_token: "my_token")
+```
+
+If you leave the `access_token` option blank, it will use the access token specified when [configuring the client](#configuring-the-client).
+
+### Jobs
+
+If you want to perform any CRUD operations on a job, you can use the `jobs` method off of the `Client`.
+
+#### Creating a job
+
+```
+job = client.jobs.create(callback_url: "https://example.com/hooks/users/324/welcome",
+                         payload: { account_id: 1234 })
 ```
 
 ## CONTRIBUTING

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Callback.configure do |config|
 end
 ```
 
+The following options are available for configuration:
+
+| Attribute      | Default                    |
+|----------------|----------------------------|
+| `access_token` | `nil`                      |
+| `base_path`    | `https://api.callback.run` |
+
 ### Creating a Client
 
 There are several endpoints that hang off of the client. The first thing you want to do is create a client.

--- a/callback-ruby.gemspec
+++ b/callback-ruby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "hashie"
   spec.add_dependency "httparty"
 
   spec.add_development_dependency "bundler"

--- a/callback-ruby.gemspec
+++ b/callback-ruby.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.5.0"
+  spec.add_development_dependency "webmock"
 end

--- a/callback-ruby.gemspec
+++ b/callback-ruby.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "httparty"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.5.0"

--- a/lib/callback.rb
+++ b/lib/callback.rb
@@ -1,3 +1,4 @@
+require "callback/api"
 require "callback/client"
 require "callback/configuration"
 require "callback/version"

--- a/lib/callback.rb
+++ b/lib/callback.rb
@@ -1,6 +1,7 @@
 require "callback/api"
 require "callback/client"
 require "callback/configuration"
+require "callback/parser"
 require "callback/version"
 
 module Callback

--- a/lib/callback.rb
+++ b/lib/callback.rb
@@ -1,3 +1,4 @@
+require "callback/client"
 require "callback/configuration"
 require "callback/version"
 

--- a/lib/callback/api.rb
+++ b/lib/callback/api.rb
@@ -1,1 +1,2 @@
+require_relative "api/base"
 require_relative "api/jobs"

--- a/lib/callback/api.rb
+++ b/lib/callback/api.rb
@@ -1,0 +1,1 @@
+require_relative "api/jobs"

--- a/lib/callback/api/base.rb
+++ b/lib/callback/api/base.rb
@@ -1,10 +1,11 @@
 module Callback
   module API
     class Base
-      attr_accessor :access_token
+      attr_accessor :access_token, :base_path
 
-      def initialize(access_token: nil)
+      def initialize(access_token: nil, base_path: nil)
         @access_token = access_token
+        @base_path = base_path
       end
     end
   end

--- a/lib/callback/api/base.rb
+++ b/lib/callback/api/base.rb
@@ -1,3 +1,5 @@
+require "httparty"
+
 module Callback
   module API
     class Base
@@ -6,6 +8,23 @@ module Callback
       def initialize(access_token: nil, base_path: nil)
         @access_token = access_token
         @base_path = base_path
+      end
+
+      protected
+
+      def request(method, path, parameters={})
+        full_path = "#{base_path}#{path}"
+
+        options = {
+          headers: {
+            "Accept"        => "application/json",
+            "Authorization" => "Bearer #{access_token}",
+            "Content-Type"  => "application/json; charset=utf-8"
+          }
+        }
+
+        response = HTTParty.send method, full_path, options
+        JSON.parse(response.body)
       end
     end
   end

--- a/lib/callback/api/base.rb
+++ b/lib/callback/api/base.rb
@@ -1,8 +1,11 @@
 require "httparty"
+require "callback/parser"
 
 module Callback
   module API
     class Base
+      include Parser
+
       attr_accessor :access_token, :base_path
 
       def initialize(access_token: nil, base_path: nil)

--- a/lib/callback/api/base.rb
+++ b/lib/callback/api/base.rb
@@ -20,11 +20,17 @@ module Callback
             "Accept"        => "application/json",
             "Authorization" => "Bearer #{access_token}",
             "Content-Type"  => "application/json; charset=utf-8"
-          }
+          },
+          format: :json
         }
+        if method.to_sym == :post
+          options[:body] = parameters.to_json
+        else
+          options[:query] = parameters
+        end
 
         response = HTTParty.send method, full_path, options
-        JSON.parse(response.body)
+        JSON.parse(response.body, symbolize_names: true)
       end
     end
   end

--- a/lib/callback/api/base.rb
+++ b/lib/callback/api/base.rb
@@ -1,0 +1,11 @@
+module Callback
+  module API
+    class Base
+      attr_accessor :access_token
+
+      def initialize(access_token: nil)
+        @access_token = access_token
+      end
+    end
+  end
+end

--- a/lib/callback/api/jobs.rb
+++ b/lib/callback/api/jobs.rb
@@ -1,6 +1,9 @@
 module Callback
   module API
     class Jobs < Base
+      def create(parameters={})
+        request :post, "/jobs", parameters
+      end
     end
   end
 end

--- a/lib/callback/api/jobs.rb
+++ b/lib/callback/api/jobs.rb
@@ -1,8 +1,6 @@
 module Callback
   module API
-    class Jobs
-      def initialize(access_token: nil)
-      end
+    class Jobs < Base
     end
   end
 end

--- a/lib/callback/api/jobs.rb
+++ b/lib/callback/api/jobs.rb
@@ -2,7 +2,7 @@ module Callback
   module API
     class Jobs < Base
       def create(parameters={})
-        request :post, "/jobs", parameters
+        parse request(:post, "/jobs", parameters)
       end
     end
   end

--- a/lib/callback/api/jobs.rb
+++ b/lib/callback/api/jobs.rb
@@ -1,0 +1,8 @@
+module Callback
+  module API
+    class Jobs
+      def initialize(access_token: nil)
+      end
+    end
+  end
+end

--- a/lib/callback/client.rb
+++ b/lib/callback/client.rb
@@ -1,0 +1,11 @@
+module Callback
+  class Client
+    attr_accessor :access_token
+
+    def initialize(options={})
+      @access_token = options.fetch(:access_token) do
+        Callback.configuration.access_token
+      end
+    end
+  end
+end

--- a/lib/callback/client.rb
+++ b/lib/callback/client.rb
@@ -7,5 +7,9 @@ module Callback
         Callback.configuration.access_token
       end
     end
+
+    def jobs
+      @jobs ||= API::Jobs.new(access_token: access_token)
+    end
   end
 end

--- a/lib/callback/client.rb
+++ b/lib/callback/client.rb
@@ -3,16 +3,18 @@ module Callback
     attr_accessor :access_token, :base_path
 
     def initialize(options={})
-      @access_token = options.fetch(:access_token) do
-        Callback.configuration.access_token
-      end
-      @base_path = options.fetch(:base_path) do
-        Callback.configuration.base_path
-      end
+      @access_token = initialize_attribute :access_token, options
+      @base_path = initialize_attribute :base_path, options
     end
 
     def jobs
       @jobs ||= API::Jobs.new(access_token: access_token, base_path: base_path)
+    end
+
+    private
+
+    def initialize_attribute(key, options)
+      options.fetch(key) { Callback.configuration.send(key) }
     end
   end
 end

--- a/lib/callback/client.rb
+++ b/lib/callback/client.rb
@@ -1,15 +1,18 @@
 module Callback
   class Client
-    attr_accessor :access_token
+    attr_accessor :access_token, :base_path
 
     def initialize(options={})
       @access_token = options.fetch(:access_token) do
         Callback.configuration.access_token
       end
+      @base_path = options.fetch(:base_path) do
+        Callback.configuration.base_path
+      end
     end
 
     def jobs
-      @jobs ||= API::Jobs.new(access_token: access_token)
+      @jobs ||= API::Jobs.new(access_token: access_token, base_path: base_path)
     end
   end
 end

--- a/lib/callback/configuration.rb
+++ b/lib/callback/configuration.rb
@@ -1,5 +1,9 @@
 module Callback
   class Configuration
     attr_accessor :access_token, :base_path
+
+    def initialize
+      @base_path = "https://api.callback.run"
+    end
   end
 end

--- a/lib/callback/configuration.rb
+++ b/lib/callback/configuration.rb
@@ -1,5 +1,5 @@
 module Callback
   class Configuration
-    attr_accessor :access_token
+    attr_accessor :access_token, :base_path
   end
 end

--- a/lib/callback/parser.rb
+++ b/lib/callback/parser.rb
@@ -1,0 +1,9 @@
+require "hashie"
+
+module Callback
+  module Parser
+    def parse(json)
+      Hashie::Mash.new json
+    end
+  end
+end

--- a/spec/api_spec_helper.rb
+++ b/spec/api_spec_helper.rb
@@ -1,0 +1,4 @@
+require "webmock/rspec"
+
+require_relative "spec_helper"
+require_relative "support/callback_stubbing_factory"

--- a/spec/callback/api/jobs_spec.rb
+++ b/spec/callback/api/jobs_spec.rb
@@ -1,0 +1,23 @@
+require "api_spec_helper"
+
+RSpec.describe Callback::API::Jobs do
+  include CallbackStubbingFactory
+
+  let(:access_token) { "TOKEN" }
+  let(:base_path) { "https://api.callback.run" }
+  let(:callback_url) { "http://example.com/hooks/users/324/welcome" }
+  let(:name) { "Send welcome email to new user" }
+  subject { described_class.new access_token: access_token, base_path: base_path }
+
+  describe "#create" do
+    it "creates a new job and returns the specified job" do
+      stub_callback_request :post, "jobs", access_token, "jobs/create_success.json",
+        "callback_url" => callback_url, "name" => name
+
+      job = subject.create callback_url: callback_url, name: name
+
+      expect(job["callback_url"]).to eq callback_url
+      expect(job["name"]).to eq name
+    end
+  end
+end

--- a/spec/callback/api/jobs_spec.rb
+++ b/spec/callback/api/jobs_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Callback::API::Jobs do
 
       job = subject.create callback_url: callback_url, name: name
 
-      expect(job[:callback_url]).to eq callback_url
-      expect(job[:name]).to eq name
+      expect(job.callback_url).to eq callback_url
+      expect(job.name).to eq name
     end
   end
 end

--- a/spec/callback/api/jobs_spec.rb
+++ b/spec/callback/api/jobs_spec.rb
@@ -10,14 +10,24 @@ RSpec.describe Callback::API::Jobs do
   subject { described_class.new access_token: access_token, base_path: base_path }
 
   describe "#create" do
-    it "creates a new job and returns the specified job" do
+    it "makes the request" do
+      request = stub_request(:post, "https://api.callback.run/jobs")
+        .with(body: hash_including(:callback_url, :name))
+        .and_return(status: 201, body: {}.to_json)
+
+      subject.create callback_url: callback_url, name: name
+
+      expect(request).to have_been_requested
+    end
+
+    it "returns the newly created job" do
       stub_callback_request :post, "jobs", access_token, "jobs/create_success.json",
         "callback_url" => callback_url, "name" => name
 
       job = subject.create callback_url: callback_url, name: name
 
-      expect(job["callback_url"]).to eq callback_url
-      expect(job["name"]).to eq name
+      expect(job[:callback_url]).to eq callback_url
+      expect(job[:name]).to eq name
     end
   end
 end

--- a/spec/callback/client_spec.rb
+++ b/spec/callback/client_spec.rb
@@ -2,10 +2,6 @@ RSpec.describe Callback::Client do
   describe "#initialize" do
     after { Callback.configuration.access_token = nil }
 
-    it "initializes with an options array" do
-      expect { described_class.new }.to_not raise_error
-    end
-
     it "can be initialized with an access token" do
       expect(described_class.new(access_token: "BLAH").access_token).to eq "BLAH"
     end
@@ -15,7 +11,13 @@ RSpec.describe Callback::Client do
         config.access_token = "BLAH"
       end
 
-      expect(described_class.new.access_token).to eq "BLAH"
+      expect(subject.access_token).to eq "BLAH"
+    end
+  end
+
+  describe "#jobs" do
+    it "returns the jobs api" do
+      expect(subject.jobs).to be_instance_of Callback::API::Jobs
     end
   end
 end

--- a/spec/callback/client_spec.rb
+++ b/spec/callback/client_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Callback::Client do
-  describe "#initialize" do
+  describe "#access_token" do
     after { Callback.configuration.access_token = nil }
 
     it "can be initialized with an access token" do
@@ -12,6 +12,23 @@ RSpec.describe Callback::Client do
       end
 
       expect(subject.access_token).to eq "BLAH"
+    end
+  end
+
+  describe "#base_path" do
+    after { Callback.configuration.access_token = nil }
+
+    it "can be initialized with an base path" do
+      expect(described_class.new(base_path: "http://blah.com").base_path).to \
+        eq "http://blah.com"
+    end
+
+    it "uses the base path from configuration if it's not specified" do
+      Callback.configure do |config|
+        config.base_path = "http://blah.com"
+      end
+
+      expect(subject.base_path).to eq "http://blah.com"
     end
   end
 

--- a/spec/callback/client_spec.rb
+++ b/spec/callback/client_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Callback::Client do
+  describe "#initialize" do
+    after { Callback.configuration.access_token = nil }
+
+    it "initializes with an options array" do
+      expect { described_class.new }.to_not raise_error
+    end
+
+    it "can be initialized with an access token" do
+      expect(described_class.new(access_token: "BLAH").access_token).to eq "BLAH"
+    end
+
+    it "uses the access token from configuration if it's not specified" do
+      Callback.configure do |config|
+        config.access_token = "BLAH"
+      end
+
+      expect(described_class.new.access_token).to eq "BLAH"
+    end
+  end
+end

--- a/spec/callback/configuration_spec.rb
+++ b/spec/callback/configuration_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Callback::Configuration do
+  context "defaults" do
+    describe "#base_path" do
+      it "defaults to the production api path" do
+        expect(subject.base_path).to eq "https://api.callback.run"
+      end
+    end
+  end
+end

--- a/spec/support/callback_stubbing_factory.rb
+++ b/spec/support/callback_stubbing_factory.rb
@@ -1,0 +1,13 @@
+module CallbackStubbingFactory
+  def callback_response_fixture(fixture)
+    File.read(File.join("spec", "support", "fixtures", fixture)).strip.gsub(/\n\s*/, "")
+  end
+
+  def stub_callback_request(method, path, access_token, fixture, values={},
+                            base_path="https://api.callback.run/")
+    full_path = "#{base_path}#{path}"
+    body = JSON.parse(callback_response_fixture(fixture)).merge(values).to_json
+    stub_request(method, full_path)
+      .to_return(status: 200, body: body)
+  end
+end

--- a/spec/support/fixtures/jobs/create_success.json
+++ b/spec/support/fixtures/jobs/create_success.json
@@ -1,0 +1,4 @@
+{
+  "callback_url": "http://example.com/jobs/1234",
+  "name": "Name"
+}


### PR DESCRIPTION
Adds the initial communication piece (important) with the callback api. Allows a client to create a job on callback.